### PR TITLE
Fix most IntelliJ Idea warnings - Abe's Improvements

### DIFF
--- a/src/main/java/me/abetgt/raft/RaftConfig.java
+++ b/src/main/java/me/abetgt/raft/RaftConfig.java
@@ -20,7 +20,10 @@ public class RaftConfig {
         file = new File(Raft.getRaftDataFolder(), "script.yml");
 
         if (!file.exists()){
-            try {file.createNewFile();} catch (IOException ignore){}
+            // Fixed warning: Warning:(23, 23) Result of 'File.createNewFile()' is ignored
+            try {file.createNewFile();} catch (IOException exception){
+                exception.printStackTrace();
+            }
         }
         customFile = YamlConfiguration.loadConfiguration(file);
     }

--- a/src/main/java/me/abetgt/raft/RaftConfig.java
+++ b/src/main/java/me/abetgt/raft/RaftConfig.java
@@ -41,10 +41,8 @@ public class RaftConfig {
     }
 
     public static boolean hasContent(){
-        if (config.getKeys(true).size() == 0){
-            return true;
-        }
-        return false;
+        // Fixed warning: Warning:(41, 9) 'if' statement can be simplified
+        return config.getKeys(true).size() == 0;
     }
 
     public static void reload(Player player){

--- a/src/main/java/me/abetgt/raft/RaftEffects.java
+++ b/src/main/java/me/abetgt/raft/RaftEffects.java
@@ -35,6 +35,7 @@ public class RaftEffects {
 
     static ArrayList<String> effectSyntaxList = new ArrayList<>();
 
+    // TODO: Make this system more efficient
     public static void runEffects(Player player, String event, Event chosenEvent){
         // c = the key for the config
         String c = event + ".";
@@ -114,6 +115,7 @@ public class RaftEffects {
             } else {
                 log_noPlayer("\"execute player command\"");
             }
+        // TODO: Fix this below
         } if (config.contains(c + "create a temp string variable named")) {
             RaftVariable variable = new RaftVariable();
             variable.createVariable(config.getString(c + "create a temp string variable named"));

--- a/src/main/java/me/abetgt/raft/RaftEffects.java
+++ b/src/main/java/me/abetgt/raft/RaftEffects.java
@@ -70,6 +70,7 @@ public class RaftEffects {
             }
         } if (config.contains(c + "broadcast")) {
             if (!(player == null)) {
+                // TODO: Workaround for deprecated broadcastMessage on Paper
                 Bukkit.broadcastMessage(Objects.requireNonNull(ChatColor.translateAlternateColorCodes('&', Objects.requireNonNull(config.getString(event + ".broadcast")))));
             } else {
                 log_noPlayer("\"broadcast\"");

--- a/src/main/java/me/abetgt/raft/RaftVariable.java
+++ b/src/main/java/me/abetgt/raft/RaftVariable.java
@@ -4,7 +4,8 @@ import java.util.HashMap;
 
 public class RaftVariable {
 
-    HashMap<String, String> variableListString = new HashMap<String, String>();
+    // Fixed warning: Warning:(7, 62) Explicit type argument String, String can be replaced with <>
+    HashMap<String, String> variableListString = new HashMap<>();
 
     public RaftVariable(){}
 


### PR DESCRIPTION
This PR fixes most of the warnings that were requested by IntelliJ Idea's code analysis.

Fixed:
- [Warning:(7, 62) Explicit type argument String, String can be replaced with <>](https://github.com/AbeTGT/Raft/pull/1/commits/dfd1b2da8e911fdab3d81a0f1b3802cee0b6373a)
- [Warning:(23, 23) Result of 'File.createNewFile()' is ignored](https://github.com/AbeTGT/Raft/pull/1/commits/3d58b3d29cf92037c0e46dac70d5959d11fb4e3f)
- [Warning:(41, 9) 'if' statement can be simplified](https://github.com/AbeTGT/Raft/pull/1/commits/a238c834988b85b21d2f400885d0820151fecca1)

Also added some notes in RaftEffects.
- [TODO: Workaround for deprecated broadcastMessage on Paper](https://github.com/AbeTGT/Raft/pull/1/commits/4178dc283c213cd83455ba6dba0fc7358338cabb)
- [TODO: Make this system more efficient & TODO: Fix this below](https://github.com/AbeTGT/Raft/pull/1/commits/83eb37df4df334d21cc0dea7f542adb3beff7d47)